### PR TITLE
Streamlining README and quickstart

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -19,19 +19,104 @@ knitr::opts_chunk$set(
 [![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 <!-- badges: end -->
 
+## Introduction
+
+This package allows creation of a web browser that can visualize a 
+variety of -omics data from multiple data formats.
+
 NDCN -Omics Browser (omicser TBC)
 CZI, NDCN -Omics Browser
 Data exploration playground for general -omics sharing.  Developed as part of the NDCN Open Science initiative Data Science Pilot March-Sept 202.
 
+The NDCN Browser (`Omicser`) was developing using `{golem}`: "an opinionated framework for building production-grade shiny applications." - https://github.com/ThinkR-open/golem
 
-# Introduction
-
-The goal is to make a shiny app which contains a simple omics data browser. A variety of data formats can be configured to browse.  Check the `Quickstart` guide.
+Note:  although the NDCN browser is not yet officially named, there are references to the browser/package as `omicser` or `omxr`.  
 
 
-# Installation
+## Dependencies and environment
 
-This shiny app is build inside an R package and can be installed with `devtools::install_github("ergonyc/omicser")`.  It is crucial to set up a python environment for reticulate which includes scanpy.
+Running this package creates a Shiny app which can load and visualize -omics data.
+It is crucial to ensure all dependencies are installed,
+and to set up a python environment that can be recognized by R.
+Other dependencies will be loaded by "omicser"
+
+There are two options for installing the required software
+and creating the necessary environments: 
+using R, or on the command line.
+
+### Option A: Via R/RStudio
+
+Execute the following commands in R to install dependencies and create your environment:
+
+```{r r_env, eval=FALSE}
+YOUR_CONDA_ENV <- "omxr"
+
+install.packages("devtools")
+install.packages("reticulate")
+
+require(reticulate)
+reticulate::install_miniconda() 
+reticulate::conda_create(YOUR_CONDA_ENV,python_version = 3.9)
+reticulate::conda_install(envname = YOUR_CONDA_ENV, packages = "scanpy")
+reticulate::conda_install(envname= YOUR_CONDA_ENV,
+                          channel = "conda-forge",
+                          packages = c("leidenalg") )
+```
+
+### Option B: Via the command line
+
+The following instructions provide an alternative to executing the above code in R:
+
+Make sure you have anaconda or mini-conda installed. e.g.
+
+```{bash, conda_inst, eval = FALSE}
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
+bash ~/miniconda.sh -b -p $HOME/miniconda
+```
+
+Then make a conda environment to use with reticulate.   For this example we've called the environment `omxr`.
+```{bash, conda_env, eval = FALSE}
+conda create --name omxr python=3.9 scanpy                                                                             
+conda install -c conda-forge leidenalg                                                                                  
+conda activate omxr
+```
+
+## Installing this package
+
+There are two ways to install this package,
+depending on how much you expect to customize the interface:  
+plug-and-play or development mode.
+
+### Option A:  Plug-and-play mode
+
+This option allows you to install the package directly from GitHub,
+and is appropriate for running the software as-is (with no customization).
+
+Run the following R code to install this package:
+
+```{r, plug_mode, eval=FALSE}
+devtools::install_github("ergonyc/omicser")
+```
+
+### Option B:  Development mode
+
+This option clones the repository before installing,
+and is appropriate if you would like to:
+- customize features of the Shiny app
+- contribute code (e.g., new features) to this project
+
+Execute the following code on the command line:
+
+```{bash, dev_mode, eval = FALSE}
+# using git
+git clone https://github.com/k8hertweck/omicser.git
+
+# using the GitHub CLI
+gh repo clone ergonyc/omicser
+```
+
+If you install the package from the command line,
+remember to install and load the package in R!
 
 # Usage
 
@@ -55,29 +140,11 @@ The file `app.R` should only contain:
 I added 2 files (positive and negative mode) as example data. After installing the package 
 you can find them in the folder `extdata`. In the repository you can find them in `inst/extdata`.
 
+## ETC. Caveats
+Several “big” updates are planned.
 
-
-## Installation
-
-You can install the current version of omicser from giuthub with:
-
-`devtools::install_github("omicser")`
-
-but first run this::
-
-```{r example, eval=FALSE}
-
-install.packages("devtools")
-install.packages("BiocManager")
-BiocManager::install("SingleCellExperiment")
-
-install.packages("reticulate")
-
-require(reticulate)
-reticulate::install_miniconda()
-reticulate::conda_create("omxr",python_version = 3.9)
-reticulate::conda_install(envname = "omxr", packages = "scanpy")
-reticulate::conda_install(envname="omxr",
-                          channel = "conda-forge",
-                          packages = c("leidenalg") )
-```
++  Consistent `roxygen2` headers.  Currently importing functions (e.g. `require(“package”)`) or using the `package::function` syntax is inconsistent.  
++ Migrate all dplyr::  tidyverse table manipulation to data.frame syntax and/or dtdplyr.  
+(test speed improvements on mac, with caveat of apple disabled multithreading)
++ Clean up directory structures Remove /data and move more things to the /inst subdirectory
++ migration to the NDCN githyb.  Currently things are in my personal github ("ergonyc")

--- a/vignettes/Quickstart.Rmd
+++ b/vignettes/Quickstart.Rmd
@@ -14,7 +14,7 @@ output:
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-## 0. Overview
+## Overview
 
 In order to use the NDCN ‘omics’ browser we need to set a few things up.  This should be four simple steps:
 
@@ -25,91 +25,10 @@ In order to use the NDCN ‘omics’ browser we need to set a few things up.  Th
 5. Run the browser!
 
 The following materials should provide a simple set of steps to accomplish this and start browsing ‘omics’!
-
-Note:  although the NDCN browser is not yet officially named, there are references to the browser/package as `omicser` or `omxr`.  
-
-## 1. Environment setup
-We will need an R environment, which could be as simple as the base RStudio R, and a python environment which we will specify with conda. (In the future we can encapsulate everything in a docker container (including RSTudio?) to make it even more straightforward.)
-
-### Option A: Environment Setup Within RStudio / R 
-
-Executing the following commands in the R console or as an R-script will set up the requisite packages/dependencies and create the python environment.  Variables in _CAPS_ sucth as `YOUR_CONDA_ENV` are customizable. 
-
-```{r, 01-env_setup-1, eval=FALSE}
-
-YOUR_CONDA_ENV <- "omxr"
-
-install.packages("devtools")
-install.packages("reticulate")
-
-require(reticulate)
-reticulate::install_miniconda() 
-reticulate::conda_create(YOUR_CONDA_ENV,python_version = 3.9)
-reticulate::conda_install(envname = YOUR_CONDA_ENV, packages = "scanpy")
-reticulate::conda_install(envname= YOUR_CONDA_ENV,
-                          channel = "conda-forge",
-                          packages = c("leidenalg") )
-
-# NOTE: all other dependencies will be loaded by "omicser"
-
-```
-
-### Option B: Using the Command Line
-
-Make sure you have anaconda or mini-conda installed. e.g.
-```{bash, 01-env_setup-2, eval = FALSE}
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O ~/miniconda.sh
-bash ~/miniconda.sh -b -p $HOME/miniconda
-```
-
-
-Then make a conda environment to use with reticulate.   For this example we've called the environment `omxr`.
-```{bash, 01-env_setup-3, eval = FALSE}
-conda create --name omxr python=3.9 scanpy                                                                             
-conda install -c conda-forge leidenalg                                                                                  
-conda activate omxr
-```
-
-
-## 2. NDCN Browser spin-up 
-
-There are two ways to set up the omicser:  
-1. Install package: Simply install the browser as-is as an R-package from github (https://github.com/ergonyc/omicser).
-2. Development mode: Clone the repository and customize for your needs.
-
-
-### Option 1:  passive mode
-
-Assuming that you have alread installed the pre-requisite such as `devtools` and `reticulate` the browser can be installed in the R-console.
-
-
-```{r, 2-setup-1, eval=FALSE}
-
-devtools::install_github("ergonyc/omicser")
-
-```
-
-
-### Option 2:  development mode
-If you would like to fine tune (or contribute to the open-source efforts!) you can clone the repo and install locally.
-
-For instance within R-studio:
-![rstuido clone](/Users/ahenrie/Projects/NDCN_dev/omicser/inst/clone_gh_inrstuido.png){width=50%}
-
-Or from the command line.  For example using the github cli:
-```{bash, 2-setup-2, eval = FALSE}
-gh repo clone ergonyc/omicser
-```
-
-From the repo home directory the library can be loaded with:
-```{r, 2-setup-3, eval=FALSE}
-
-library("omicser")
-
-```
-
+This document assumes software installation and environment configuration documented in the README.  
     
-## 3. Data Prep
+## Data curation and preparation
+
 The most crucial step is _curating_ your data into a database that can be loaded by the browser.  As the _curator_ you will have the responsibility to make some choices about what and how the data can be seen.  
 This process results in specifying the location of the data, and creating files which are formatted for the browser.
 
@@ -117,7 +36,6 @@ As an example there is the `curate_domenico_stem_cell.R` script in the /examples
 
 The process as illustrated in the example can be broken into the following steps:
 
-0. preamble / setup - make sure all the required tools/repos are loaded
 1. provenance & meta data setup - define the meta-data and context for the dataset
 2. helper function definition - any helpers you need
 3. raw data ingest - load the raw data from whatever format they live in
@@ -153,9 +71,9 @@ configr::write.config(config.dat = omicser_options, file.path = "omxr_options.ym
 ```
 
 The anndata scheme requires us to define three main tables:
-1. the omic data matrix - e.g. transcriptomics - count matrix of cells X genes.
-2. omic annotation data - e.g. gene families, "highly variable genes", "is marker gene"
-3. sample meta data - e.g.  sex, experiemntal condition, etc.
+- the omic data matrix - e.g. transcriptomics - count matrix of cells X genes.
+- omic annotation data - e.g. gene families, "highly variable genes", "is marker gene"
+- sample meta data - e.g.  sex, experiemntal condition, etc.
 
 We also need to define differential omic-expression tables.
 
@@ -272,9 +190,7 @@ configr::write.config(config.dat = conf_list, file.path = file.path(DS_ROOT_PATH
 
 ```
 
-
-
-## 4. Browse!!
+## Browse!!
 
 Assuming you have already loaded the omicser package, once the .yml files have been generated and teh data placed in the right directories you are good to browse!
 
@@ -285,18 +201,3 @@ run_app(options = list(launch.browser = TRUE))
 ```
 
 Note, that if you are using a development setup, you might want to run the run_dev script which will handle unloading / re-loading for you.
-
-
-## ETC.Background (etc.)
-
-The NDCN Browser (`Omicser`) was developing using `{golem}`: "an opinionated framework for building production-grade shiny applications." - https://github.com/ThinkR-open/golem
-
-
-## ETC. Caveats
-Several “big” updates are planned.
-
-+  Consistent `roxygen2` headers.  Currently importing functions (e.g. `require(“package”)`) or using the `package::function` syntax is inconsistent.  
-+ Migrate all dplyr::  tidyverse table manipulation to data.frame syntax and/or dtdplyr.  
-(test speed improvements on mac, with caveat of apple disabled multithreading)
-+ Clean up directory structures Remove /data and move more things to the /inst subdirectory
-+ migration to the NDCN githyb.  Currently things are in my personal github ("ergonyc")


### PR DESCRIPTION
Matching content between README and Quickstart vignette:
- [x] README includes installing software/packages, creating environment, running browser
- [ ] Quickstart focuses on curating data
- [ ] image that shows flowchart of how process works (from data generation through browsing)

Feel free to disregard as you see fit; this helped things make sense to me and I think will help with scaling up to other users!